### PR TITLE
Fix Windows ARM Rust target selection

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
-    continue-on-error: ${{ matrix.config.experimental }}
+    continue-on-error: ${{ matrix.config.experimental == true }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
@@ -20,12 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release', experimental: false, rust-target: ''}
-          - {os: windows-latest, r: 'release', experimental: false, rust-target: 'x86_64-pc-windows-gnu'}
-          - {os: windows-11-arm, r: 'release', experimental: true,  rust-target: 'aarch64-pc-windows-gnullvm'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release', experimental: false, rust-target: ''}
-          - {os: ubuntu-latest,   r: 'release', experimental: false, rust-target: ''}
-          - {os: ubuntu-latest,   r: 'oldrel-1', experimental: false, rust-target: ''}
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: windows-11-arm, r: 'release', experimental: true}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -42,9 +42,9 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Add Rust target
-        if: ${{ matrix.config.rust-target != '' }}
-        run: rustup target add ${{ matrix.config.rust-target }}
+      - name: Add Windows ARM Rust target
+        if: ${{ matrix.config.os == 'windows-11-arm' }}
+        run: rustup target add aarch64-pc-windows-gnullvm
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,6 +12,7 @@ permissions: read-all
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
+    continue-on-error: ${{ matrix.config.experimental }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
@@ -19,11 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: macos-latest,   r: 'release', experimental: false, rust-target: ''}
+          - {os: windows-latest, r: 'release', experimental: false, rust-target: 'x86_64-pc-windows-gnu'}
+          - {os: windows-11-arm, r: 'release', experimental: true,  rust-target: 'aarch64-pc-windows-gnullvm'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release', experimental: false, rust-target: ''}
+          - {os: ubuntu-latest,   r: 'release', experimental: false, rust-target: ''}
+          - {os: ubuntu-latest,   r: 'oldrel-1', experimental: false, rust-target: ''}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +41,10 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+
+      - name: Add Rust target
+        if: ${{ matrix.config.rust-target != '' }}
+        run: rustup target add ${{ matrix.config.rust-target }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,6 @@ Config/testthat/parallel: false
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
-SystemRequirements: Cargo (Rust's package manager), rustc >= 1.70.0, xz
+SystemRequirements: Cargo (Rust's package manager), rustc >= 1.70.0, xz.
+    On Windows ARM64, source installs also require Microsoft C++ Build
+    Tools with ARM64 components.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # yaml12 (development version)
 
+* Fixed source installs on Windows ARM64 by selecting the
+  `aarch64-pc-windows-gnullvm` Rust target. Windows source installs now also
+  fail early with instructions if the required Rust target is not installed.
+  The README documents that Windows ARM64 source installs also require
+  Microsoft C++ Build Tools with ARM64 components.
+
 * Added a benchmarks article comparing read/write performance against the
   `yaml` package (#2).
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,6 +45,20 @@ You can install the development version of yaml12 from
 pak::pak("posit-dev/r-yaml12")
 ```
 
+### Windows ARM64 source installs
+
+On Windows ARM64, source installs require the Rust target used by
+Rtools45:
+
+``` sh
+rustup target add aarch64-pc-windows-gnullvm
+```
+
+They also require Microsoft C++ Build Tools with ARM64 components. Cargo
+uses the Microsoft linker for host-side Rust procedural macros during
+the source build. Binary installs do not run Cargo and do not need this
+setup.
+
 ## Quick start
 
 ```{r}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ You can install the development version of yaml12 from
 pak::pak("posit-dev/r-yaml12")
 ```
 
+### Windows ARM64 source installs
+
+On Windows ARM64, source installs require the Rust target used by
+Rtools45:
+
+``` sh
+rustup target add aarch64-pc-windows-gnullvm
+```
+
+They also require Microsoft C++ Build Tools with ARM64 components. Cargo
+uses the Microsoft linker for host-side Rust procedural macros during
+the source build. Binary installs do not run Cargo and do not need this
+setup.
+
 ## Quick start
 
 ``` r

--- a/configure.win
+++ b/configure.win
@@ -1,2 +1,3 @@
 #!/usr/bin/env sh
+"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/windows-rust-target.R --check
 "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/config.R

--- a/src/Makevars.win.in
+++ b/src/Makevars.win.in
@@ -1,4 +1,4 @@
-TARGET = $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
+TARGET = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript.exe" "../tools/windows-rust-target.R")
 
 TARGET_DIR = ./rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/@LIBDIR@

--- a/tests/testthat/test-windows-rust-target.R
+++ b/tests/testthat/test-windows-rust-target.R
@@ -1,0 +1,47 @@
+load_windows_rust_target <- function() {
+  env <- new.env(parent = baseenv())
+  source(test_path("../../tools/windows-rust-target.R"), local = env)
+  env$windows_rust_target
+}
+
+test_that("windows Rust target selection supports ARM Windows", {
+  windows_rust_target <- load_windows_rust_target()
+
+  expect_identical(
+    windows_rust_target(
+      platform = "aarch64-w64-mingw32",
+      arch = "aarch64",
+      compiled_by = "clang"
+    ),
+    "aarch64-pc-windows-gnullvm"
+  )
+
+  expect_identical(
+    windows_rust_target(
+      platform = "x86_64-w64-mingw32",
+      arch = "x86_64",
+      compiled_by = "gcc"
+    ),
+    "x86_64-pc-windows-gnu"
+  )
+
+  expect_identical(
+    windows_rust_target(
+      platform = "i386-w64-mingw32",
+      arch = "i386",
+      compiled_by = "gcc"
+    ),
+    "i686-pc-windows-gnu"
+  )
+})
+
+test_that("windows Makevars uses the Rust target helper", {
+  makevars_win <- readLines(test_path("../../src/Makevars.win.in"))
+
+  expect_true(any(grepl("windows-rust-target.R", makevars_win, fixed = TRUE)))
+  expect_false(any(grepl(
+    "$(WIN)))-pc-windows-gnu",
+    makevars_win,
+    fixed = TRUE
+  )))
+})

--- a/tests/testthat/test-windows-rust-target.R
+++ b/tests/testthat/test-windows-rust-target.R
@@ -64,3 +64,32 @@ test_that("windows Makevars uses the Rust target helper", {
     fixed = TRUE
   )))
 })
+
+test_that("windows Rust target check reports missing targets", {
+  env <- new.env(parent = baseenv())
+  source(source_file("tools", "windows-rust-target.R"), local = env)
+
+  expect_no_error(env$check_windows_rust_target(
+    target = "aarch64-pc-windows-gnullvm",
+    installed_targets = "aarch64-pc-windows-gnullvm"
+  ))
+
+  expect_error(
+    env$check_windows_rust_target(
+      target = "aarch64-pc-windows-gnullvm",
+      installed_targets = "x86_64-pc-windows-gnu"
+    ),
+    "rustup target add aarch64-pc-windows-gnullvm",
+    fixed = TRUE
+  )
+})
+
+test_that("configure.win checks the Rust target before configuring", {
+  configure_win <- readLines(source_file("configure.win"))
+  check_line <- grep("windows-rust-target.R.*--check", configure_win)
+  config_line <- grep("tools/config.R", configure_win, fixed = TRUE)
+
+  expect_length(check_line, 1L)
+  expect_length(config_line, 1L)
+  expect_lt(check_line, config_line)
+})

--- a/tests/testthat/test-windows-rust-target.R
+++ b/tests/testthat/test-windows-rust-target.R
@@ -1,6 +1,25 @@
+source_file <- function(...) {
+  paths <- list(...)
+  candidates <- c(
+    do.call(test_path, c(list("..", ".."), paths)),
+    do.call(
+      file.path,
+      c(list(getwd(), "..", "..", "00_pkg_src", "yaml12"), paths)
+    )
+  )
+
+  for (candidate in candidates) {
+    if (file.exists(candidate)) {
+      return(candidate)
+    }
+  }
+
+  skip("Source file is not available in this test layout")
+}
+
 load_windows_rust_target <- function() {
   env <- new.env(parent = baseenv())
-  source(test_path("../../tools/windows-rust-target.R"), local = env)
+  source(source_file("tools", "windows-rust-target.R"), local = env)
   env$windows_rust_target
 }
 
@@ -36,7 +55,7 @@ test_that("windows Rust target selection supports ARM Windows", {
 })
 
 test_that("windows Makevars uses the Rust target helper", {
-  makevars_win <- readLines(test_path("../../src/Makevars.win.in"))
+  makevars_win <- readLines(source_file("src", "Makevars.win.in"))
 
   expect_true(any(grepl("windows-rust-target.R", makevars_win, fixed = TRUE)))
   expect_false(any(grepl(

--- a/tools/windows-rust-target.R
+++ b/tools/windows-rust-target.R
@@ -1,0 +1,57 @@
+windows_rust_target <- function(
+  platform = R.version$platform,
+  arch = R.version$arch,
+  compiled_by = Sys.getenv("R_COMPILED_BY")
+) {
+  stopifnot(
+    is.character(platform),
+    length(platform) == 1L,
+    !is.na(platform),
+    is.character(arch),
+    length(arch) == 1L,
+    !is.na(arch),
+    is.character(compiled_by),
+    length(compiled_by) == 1L,
+    !is.na(compiled_by)
+  )
+
+  platform <- tolower(platform)
+  arch <- tolower(arch)
+
+  if (!grepl("mingw|windows", platform)) {
+    stop(
+      "Expected a Windows platform, not `",
+      platform,
+      "`",
+      call. = FALSE
+    )
+  }
+
+  if (startsWith(platform, "aarch64-") || identical(arch, "aarch64")) {
+    return("aarch64-pc-windows-gnullvm")
+  }
+
+  if (startsWith(platform, "i386-") || identical(arch, "i386")) {
+    return("i686-pc-windows-gnu")
+  }
+
+  if (startsWith(platform, "x86_64-") || identical(arch, "x86_64")) {
+    if (grepl("clang", compiled_by, ignore.case = TRUE)) {
+      return("x86_64-pc-windows-gnullvm")
+    }
+    return("x86_64-pc-windows-gnu")
+  }
+
+  stop(
+    "Unknown Windows architecture: `",
+    arch,
+    "` for platform `",
+    platform,
+    "`",
+    call. = FALSE
+  )
+}
+
+if (sys.nframe() == 0L) {
+  cat(windows_rust_target())
+}

--- a/tools/windows-rust-target.R
+++ b/tools/windows-rust-target.R
@@ -52,6 +52,70 @@ windows_rust_target <- function(
   )
 }
 
+installed_rust_targets <- function(rustup = Sys.which("rustup")) {
+  stopifnot(
+    is.character(rustup),
+    length(rustup) == 1L,
+    !is.na(rustup)
+  )
+
+  rustup <- unname(rustup)
+  if (identical(rustup, "")) {
+    stop(
+      "`rustup` is required to verify the Windows Rust target.",
+      call. = FALSE
+    )
+  }
+
+  targets <- system2(
+    rustup,
+    c("target", "list", "--installed"),
+    stdout = TRUE,
+    stderr = TRUE
+  )
+  status <- attr(targets, "status", exact = TRUE)
+
+  if (!is.null(status) && status != 0L) {
+    stop(
+      "Failed to list installed Rust targets with `rustup target list --installed`.",
+      call. = FALSE
+    )
+  }
+
+  targets[nzchar(targets)]
+}
+
+check_windows_rust_target <- function(
+  target = windows_rust_target(),
+  installed_targets = installed_rust_targets()
+) {
+  stopifnot(
+    is.character(target),
+    length(target) == 1L,
+    !is.na(target),
+    is.character(installed_targets),
+    !anyNA(installed_targets)
+  )
+
+  if (target %in% installed_targets) {
+    return(invisible(target))
+  }
+
+  stop(
+    "Rust target `",
+    target,
+    "` is required to build yaml12 on this Windows platform.\n",
+    "Run: rustup target add ",
+    target,
+    call. = FALSE
+  )
+}
+
 if (sys.nframe() == 0L) {
-  cat(windows_rust_target())
+  args <- commandArgs(trailingOnly = TRUE)
+  if (identical(args, "--check")) {
+    check_windows_rust_target()
+  } else {
+    cat(windows_rust_target())
+  }
 }


### PR DESCRIPTION
## Summary

- Select the Windows Rust target with an R helper script instead of deriving it from `$(WIN)`, so native ARM Windows builds use `aarch64-pc-windows-gnullvm`.
- Preserve existing Windows x86 target behavior, including the LLVM `gnullvm` target for clang-based x64 builds.
- Add regression coverage for the Windows Rust target mapping and the Makevars template.
- Add an experimental `windows-11-arm` CI leg to exercise the ARM Windows build path.

Related to https://github.com/r-lib/Rapp/issues/39.

## Public facing changes

- Source installs on Windows ARM64 should pass Cargo a valid `aarch64-pc-windows-gnullvm` target instead of the invalid `-pc-windows-gnu` target.
- No R API changes.

## Internal-only changes

- Added `tools/windows-rust-target.R` for the Windows package build path.
- Updated `src/Makevars.win.in` to call that helper.
- Added testthat coverage for ARM64, x64, and i386 target selection.
- Made the source-file assertions work in both devtools and `R CMD check` test layouts.
- Added a non-blocking GitHub Actions matrix entry for `windows-11-arm` and explicit Rust target installation for Windows jobs.

## Additional notes

Local validation passed, and GitHub Actions is green on PR #10, including `windows-11-arm`.
