### PR TITLE
Preserve leading whitespace in literal YAML blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,10 +11,10 @@
   fallback. Mapping keys longer than YAML's implicit-key limit use explicit
   mapping syntax.
 
-* Multiline literal blocks now keep physical blank lines empty and preserve
-  later-indented lines when the first nonempty line establishes the base
-  indentation. Root literal content is indented so document markers inside a
-  string cannot end the scalar.
+* Multiline literal blocks now use explicit indentation indicators to preserve
+  leading spaces or tabs. They keep physical blank lines empty and preserve
+  later-indented lines. Root literal content is indented so document markers
+  inside a string cannot end the scalar.
 
 * `format_yaml()` and `write_yaml()` now quote strings only when YAML 1.2
   requires it. Strings such as `"yes"`, `"don't"`, `"a,b"`, `"f[0]"`, or

--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -73,8 +73,9 @@ dbg_yaml <- function(text) invisible(.Call(wrap__dbg_yaml, text))
 #' unchanged. Strings that cannot be folded losslessly use a literal or quoted
 #' representation, and mapping keys are never wrapped.
 #'
-#' Literal blocks keep physical blank lines empty and preserve later-indented
-#' lines when the first nonempty line establishes the base indentation.
+#' Literal blocks use explicit indentation indicators when needed to preserve
+#' leading spaces or tabs. They keep physical blank lines empty and preserve
+#' later-indented lines.
 #'
 #' @param value Any R object composed of lists, atomic vectors, and scalars.
 #' @param path Scalar string file path to write YAML to when using `write_yaml()`.

--- a/man/format_yaml.Rd
+++ b/man/format_yaml.Rd
@@ -42,8 +42,9 @@ breaks and all other string content round-trip through \code{parse_yaml()}
 unchanged. Strings that cannot be folded losslessly use a literal or quoted
 representation, and mapping keys are never wrapped.
 
-Literal blocks keep physical blank lines empty and preserve later-indented
-lines when the first nonempty line establishes the base indentation.
+Literal blocks use explicit indentation indicators when needed to preserve
+leading spaces or tabs. They keep physical blank lines empty and preserve
+later-indented lines.
 }
 \examples{
 cat(format_yaml(list(foo = 1, bar = list(TRUE, NA))))

--- a/src/rust/src/emitter.rs
+++ b/src/rust/src/emitter.rs
@@ -450,6 +450,10 @@ fn is_valid_literal_block_scalar(string: &str) -> bool {
     })
 }
 
+fn first_content_byte(string: &str) -> Option<u8> {
+    string.bytes().find(|&byte| byte != b'\n')
+}
+
 /// Check that block indentation and clip chomping preserve the scalar exactly.
 /// Multiple trailing newlines require keep chomping, which this emitter does
 /// not produce. An all-empty multiline value may be consumed as separation
@@ -457,16 +461,13 @@ fn is_valid_literal_block_scalar(string: &str) -> bool {
 fn is_safe_literal_block_scalar(string: &str) -> bool {
     is_valid_literal_block_scalar(string)
         && !string.ends_with("\n\n")
-        && string.split('\n').any(|line| !line.is_empty())
+        && first_content_byte(string).is_some()
 }
 
 /// An explicit indentation indicator prevents leading spaces or a tab on the
 /// first nonempty line from being mistaken for the block's indentation.
 fn needs_explicit_block_indent(string: &str) -> bool {
-    string
-        .split('\n')
-        .find(|line| !line.is_empty())
-        .is_some_and(|line| line.starts_with([' ', '\t']))
+    matches!(first_content_byte(string), Some(b' ' | b'\t'))
 }
 
 fn has_edge_whitespace(string: &str) -> bool {

--- a/src/rust/src/emitter.rs
+++ b/src/rust/src/emitter.rs
@@ -256,11 +256,13 @@ impl<'a> YamlEmitter<'a> {
     }
 
     fn emit_literal_block(&mut self, v: &str) -> EmitResult {
-        let ends_with_newline = v.ends_with('\n');
-        if ends_with_newline {
-            self.writer.write_str("|")?;
-        } else {
-            self.writer.write_str("|-")?;
+        self.writer.write_str("|")?;
+        if needs_explicit_block_indent(v) {
+            let indent_indicator = self.best_indent;
+            write!(self.writer, "{indent_indicator}")?;
+        }
+        if !v.ends_with('\n') {
+            self.writer.write_str("-")?;
         }
 
         let indent = self.block_indent();
@@ -448,19 +450,23 @@ fn is_valid_literal_block_scalar(string: &str) -> bool {
     })
 }
 
-/// Check that the emitter's implicit indentation and clip chomping preserve
-/// the scalar exactly. The first nonempty line establishes the base
-/// indentation; later lines may be more indented. Multiple trailing newlines
-/// need an explicit block scalar indicator, which this emitter does not
-/// produce. An all-empty multiline value has no base indentation and may be
-/// consumed as separation before the following node, so it is quoted.
+/// Check that block indentation and clip chomping preserve the scalar exactly.
+/// Multiple trailing newlines require keep chomping, which this emitter does
+/// not produce. An all-empty multiline value may be consumed as separation
+/// before the following node, so it is quoted.
 fn is_safe_literal_block_scalar(string: &str) -> bool {
     is_valid_literal_block_scalar(string)
         && !string.ends_with("\n\n")
-        && string
-            .split('\n')
-            .find(|line| !line.is_empty())
-            .is_some_and(|line| !line.starts_with([' ', '\t']))
+        && string.split('\n').any(|line| !line.is_empty())
+}
+
+/// An explicit indentation indicator prevents leading spaces or a tab on the
+/// first nonempty line from being mistaken for the block's indentation.
+fn needs_explicit_block_indent(string: &str) -> bool {
+    string
+        .split('\n')
+        .find(|line| !line.is_empty())
+        .is_some_and(|line| line.starts_with([' ', '\t']))
 }
 
 fn has_edge_whitespace(string: &str) -> bool {

--- a/tests/testthat/test-format-yaml.R
+++ b/tests/testthat/test-format-yaml.R
@@ -353,16 +353,61 @@ test_that("format_yaml indents root literal content", {
   }
 })
 
+test_that("format_yaml explicitly indents literal blocks with leading whitespace", {
+  value <- "  indented\nnext"
+  cases <- list(
+    root = list(
+      object = value,
+      expected = "|2-\n    indented\n  next"
+    ),
+    sequence = list(
+      object = list(value),
+      expected = "- |2-\n    indented\n  next"
+    ),
+    mapping = list(
+      object = list(body = value),
+      expected = "body: |2-\n    indented\n  next"
+    ),
+    nested = list(
+      object = list(outer = list(body = value)),
+      expected = "outer:\n  body: |2-\n      indented\n    next"
+    )
+  )
+
+  for (context in names(cases)) {
+    expect_yaml_emission(
+      cases[[context]]$object,
+      cases[[context]]$expected,
+      info = context
+    )
+  }
+
+  values <- list(
+    leading_tab = list(
+      value = "\tindented\nnext",
+      expected = "body: |2-\n  \tindented\n  next"
+    ),
+    leading_empty_line = list(
+      value = "\n  indented\nnext",
+      expected = "body: |2-\n\n    indented\n  next"
+    ),
+    clip = list(
+      value = "  indented\nnext\n",
+      expected = "body: |2\n    indented\n  next"
+    )
+  )
+
+  for (case_name in names(values)) {
+    expect_yaml_emission(
+      list(body = values[[case_name]]$value),
+      values[[case_name]]$expected,
+      info = case_name
+    )
+  }
+})
+
 test_that("format_yaml retains conservative multiline fallbacks", {
   quoted <- list(
-    leading_spaces = c(
-      value = "  indented\nnext",
-      expected = "body: \"  indented\\nnext\""
-    ),
-    leading_tab = c(
-      value = "\tindented\nnext",
-      expected = "body: \"\\tindented\\nnext\""
-    ),
     trailing_newlines = c(
       value = "alpha\nbeta\n\n",
       expected = "body: \"alpha\\nbeta\\n\\n\""


### PR DESCRIPTION
## Summary

Multiline strings whose first nonempty line begins with spaces or a tab currently fall back to double quotes. Implicit block indentation cannot distinguish those spaces from YAML structure. The emitter now uses an explicit indentation indicator when needed, so these values remain readable literal blocks and still round-trip exactly.

## User-facing changes

- `format_yaml()` and `write_yaml()` now emit `|2-` or `|2` for literal blocks whose first nonempty line has leading spaces or a tab.
- Existing unindented literal blocks keep their current `|-` or `|` form.
- Mapping keys, all-empty multiline values, and values with multiple trailing newlines retain their existing quoted fallback.

## Internal changes

- Add a focused indentation-indicator check to the Rust emitter while retaining its two-space indentation.
- Cover root, sequence, mapping, nested, tab, initial blank-line, and clip-chomping cases through public R API round trips.
- Update the generated API documentation and NEWS.
